### PR TITLE
Fix encoding for windows platforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Pogam
   :target: https://choosealicense.com/licenses/mit/
   :alt: MIT License
 
-A web scraper for (French) real estate listings.
+🕸️A web scraper for (French) real estate listings.🏠
 
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Pogam
   :target: https://choosealicense.com/licenses/mit/
   :alt: MIT License
 
-🕸️A web scraper for (French) real estate listings.🏠
+A web scraper for (French) real estate listings.
 
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ EXTRAS = []
 version = {}
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, "README.rst")) as f:
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     readme = f.read()
 
 with open(path.join(here, "LICENSE")) as f:


### PR DESCRIPTION
## Summary

`pip`install fails on Windows: there are unicode-only characters in the readme file but Windows terminals seem to be defaulting to [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) encoding.
We explicitely load utf-8 encoding.