### PR TITLE
Honor exit conditions in lbc scraper

### DIFF
--- a/pogam/scrapers/leboncoin.py
+++ b/pogam/scrapers/leboncoin.py
@@ -153,6 +153,7 @@ def leboncoin(
     added_listings: List[Listing] = []
     seen_listings: List[Listing] = []
     failed_listings: List[str] = []
+    done = -1
     while not done_with_all_pages:
 
         search_attempts = 0
@@ -191,7 +192,6 @@ def leboncoin(
         response = request.json()
 
         # parse json
-        done = -1
         consecutive_duplicates = 0
         for i, ad in enumerate(response.get("ads", [])):
             done += 1

--- a/pogam/scrapers/leboncoin.py
+++ b/pogam/scrapers/leboncoin.py
@@ -154,6 +154,7 @@ def leboncoin(
     seen_listings: List[Listing] = []
     failed_listings: List[str] = []
     done = -1
+    consecutive_duplicates = 0
     while not done_with_all_pages:
 
         search_attempts = 0
@@ -192,7 +193,6 @@ def leboncoin(
         response = request.json()
 
         # parse json
-        consecutive_duplicates = 0
         for i, ad in enumerate(response.get("ads", [])):
             done += 1
             url = ad.get("url")


### PR DESCRIPTION
## Summary

During a scrape run of leboncoin, we currently loose track of the number of listing scraped when switching to the next page of results. 

We fix that.