### PR TITLE
Parallelize scrape jobs by source and post codes

### DIFF
--- a/app/scrapes-api/handlers.py
+++ b/app/scrapes-api/handlers.py
@@ -1,3 +1,4 @@
+import itertools as it
 import json
 import logging
 import os
@@ -52,6 +53,19 @@ def run(event, context):
         raise ValueError(msg)
     sources = search.pop("sources")
 
+    sources_postcodes = it.product(sources, search["post_codes"])
+    if len(sources_postcodes) > 1:
+        for source, post_code in sources_postcodes:
+            search["sources"] = [source]
+            search["post_codes"] = [post_code]
+            data = {"search": search}
+            lambda_ = boto3.client("lambda")
+            lambda_.invoke(
+                FunctionName=context.function_name,
+                InvocationType="Event",
+                Payload=json.dumps(data),
+            )
+        return
     app = create_app()
     added_listings: List[Listing] = []
     seen_listings: List[Listing] = []

--- a/app/scrapes-api/serverless.yml
+++ b/app/scrapes-api/serverless.yml
@@ -46,6 +46,10 @@ provider:
     - Effect: Allow
       Action: "sns:*"
       Resource: "*"
+    - Effect: Allow
+      Action:
+        - lambda:InvokeFunction
+      Resource: "*"
   apiGateway:
     restApiId:
       Fn::ImportValue: "${self:custom.stage}ApiGatewayRestApiId"


### PR DESCRIPTION
## Summary

Whenever a job involves more than one (source, post code) pair, we split it and run each of the pairs in parallel. The initial motivation is to make sure that failures of one source doesn't prevent execution from other source. 
Collateral benefits are potentially faster execution from horizontal scaling. Collateral damage is that we by submitting concurrent requests to a given source for multiple post codes, we increase the chances of getting Captcha'ed.