### PR TITLE
Fix travis automated deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ after_success:
   - >
     test $TRAVIS_BRANCH = "master" &&
     test $TRAVIS_PULL_REQUEST = "false" &&
-    pipenv run make deploy-prod
+    pipenv run make deploy-app

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ script:
   pipenv run make integration
 after_success:
   - bash <(curl -s https://codecov.io/bash) -y .ci/codecov.yml
-deploy:
-  provider: script
-  script: make deploy-prod
-  on:
-    branch: master
+  - >
+    test $TRAVIS_BRANCH = "master" &&
+    test $TRAVIS_PULL_REQUEST = "false" &&
+    pipenv run make deploy-prod

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ gh-pages:
 	@git commit -m "Generated gh-pages for `git log master -1 --pretty=short --abbrev-commit`"; git push $$(git rev-parse --abbrev-ref gh-pages@{upstream} | grep -o '[^//]*' | head -1) gh-pages ; git checkout master
 	@git stash pop
 
-deploy-prod:
+deploy-app:
 	@pogam app deploy prod
-	@make gh-pages
 
 .PHONY: help Makefile docs tests


### PR DESCRIPTION
## Summary

Bugfix of #27 
It turns out the `deploy` phase in travis is ran in a subshell that is a bit finicky to configure in terms of dependencies, environment variables, etc. See https://github.com/travis-ci/travis-ci/issues/8445
We move the deploy script in `after_success` phase instead.